### PR TITLE
feature: dump data in Fuse JSON format

### DIFF
--- a/scripts/dump_athletes.py
+++ b/scripts/dump_athletes.py
@@ -187,11 +187,12 @@ def convert_value(value_obj):
 
 
 def main():
-    filename = os.environ.get('PEOPLE_NDJSON', 'var/people.ndjson')
+    filename = os.environ.get('PEOPLE_JSON', 'var/athletes.json')
+    items = []
+    for person in iterate_fuse_objects():
+        items.append(person)
     with open(filename, 'w') as f:
-        for person in iterate_fuse_objects():
-            json.dump(person, f)
-            f.write('\n')
+        json.dump({'items': items}, f, indent=2)
 
 
 if __name__ == '__main__':

--- a/scripts/upload_athletes.py
+++ b/scripts/upload_athletes.py
@@ -1,9 +1,16 @@
 from urlparse import urlparse
 import json
 import os
+import time
+import sys
 
 import requests
 
+SLEEP_INTERVAL = 0.5
+
+def print_dot():
+    sys.stdout.write(".")
+    sys.stdout.flush()
 
 def get_server_address():
     """ Try to figure out docker host from DOCKER_HOST.
@@ -17,27 +24,32 @@ def get_server_address():
 def main():
     server_address = get_server_address()
 
-    items = []
-    filename = os.environ.get('PEOPLE_NDJSON', 'var/people.ndjson')
+    print "Upload data"
+    filename = os.environ.get('PEOPLE_JSON', 'var/athletes.json')
     with open(filename) as f:
-        for line in f:
-            items.append(json.loads(line))
-
-    data = {'items': items}
+        data = json.load(f)
     res = requests.post(
         'http://%s:8000/api/tasks/types/update' % server_address,
         json=data)
     res.raise_for_status()
+    print "Wait for data ingest task"
     taskurl = res.headers['location']
     while True:
+        print_dot()
         res = requests.get(taskurl).json()
         if res['done']:
             taskurl = res['index_task']['@id']
             break
+        time.sleep(SLEEP_INTERVAL)
+    print "\n"
+    print "Wait for index task"
     while True:
+        print_dot()
         res = requests.get(taskurl).json()
         if res['done']:
             break
+        time.sleep(SLEEP_INTERVAL)
+    print "\n"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of people.ndjson create athletes.json, which is a "normal" Fuse data file.
This can be used with the management interface.

Open: upload athletes to AWS and adjust buildout task accordingly.